### PR TITLE
docker: add docs volume to mount host directory from container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,10 +4,11 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       target: orbit
+    volumes:
+      - ../docs:/orbit/docs
     ports:
       - 80:80
       - 443:443
       - 465:465
       - 995:995
       - 8448:8448
-


### PR DESCRIPTION
For systems with SELinux enabled, you will need to run:
	chcon -Rt svirt_sandbox_file_t docs
from the respository on the host to allow docker to access the files mounted from outside its container.

This change enables instantanous in-container efficacy of document updates made from the host.